### PR TITLE
Fix typo in monad anti-tutorial

### DIFF
--- a/blog/monad-anti-tutorial.md
+++ b/blog/monad-anti-tutorial.md
@@ -92,7 +92,7 @@ bar a b =
     a >>= \a' ->
     let a'' = a' + 1 in
     b >>= \b' ->
-    return (a'' + b)
+    return (a'' + b')
 ```
 
 Sometimes you don't care about the variable on the left hand side of the `<-`,


### PR DESCRIPTION
It's a minor typo, but might confuse people new to monads.