### PR TITLE
Use `ghc-syntax-highlighter` for Haskell code blocks

### DIFF
--- a/css/syntax.css
+++ b/css/syntax.css
@@ -1,5 +1,5 @@
 pre > code.sourceCode { white-space: pre; position: relative; }
-pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+pre > code.sourceCode > span { line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
 div.sourceCode { margin: 1em 0; }

--- a/website.cabal
+++ b/website.cabal
@@ -8,7 +8,11 @@ license-file:        LICENSE
 executable site
   main-is:          site.hs
   build-depends:    base == 4.*
+                  , blaze-html
+                  , ghc-syntax-highlighter
                   , hakyll
                   , filepath
+                  , pandoc
+                  , text
   ghc-options:      -threaded -rtsopts -with-rtsopts=-N
   default-language: Haskell2010

--- a/website.nix
+++ b/website.nix
@@ -1,10 +1,10 @@
-{ mkDerivation, base, filepath, hakyll, lib }:
+{ mkDerivation, base, blaze-html, filepath, hakyll, ghc-syntax-highlighter, pandoc, text, lib }:
 mkDerivation {
   pname = "website";
   version = "0.1.0.0";
   src = ./.;
   isLibrary = false;
   isExecutable = true;
-  executableHaskellDepends = [ base filepath hakyll ];
+  executableHaskellDepends = [ base blaze-html filepath hakyll ghc-syntax-highlighter pandoc text ];
   license = lib.licenses.bsd3;
 }


### PR DESCRIPTION
With thanks to https://tony-zorman.com/posts/2023-01-21-pygmentising-hakyll.html.